### PR TITLE
More efficient bot output

### DIFF
--- a/assets/bot_commands/de.md
+++ b/assets/bot_commands/de.md
@@ -1,4 +1,4 @@
-Änderungssatz `{ch_id}`
+Änderungssatz [{ch_id}]({osm_link}) - „{comment}“
 
 ❗️ Einstufung: {grade}
 ⚠️ Gründe:
@@ -7,8 +7,6 @@
 📅 Datum und Zeit: `{date}`
 📍 Ort: {location}
 🧑🏽‍💻 #User_{user_id}: [{username}]({userlink})
-
-📃 Kommentar: {comment}
 📃 Quelle: {source}
 
-📎 Weiterführende Links: [OSM]({osm_link}), [OSMcha]({osmcha_link}), [OSMvis]({osmvis_link}), [Achavi]({achavi_link})
+📎 Weiterführende Links: [OSMcha]({osmcha_link}), [OSMvis]({osmvis_link}), [Achavi]({achavi_link})

--- a/assets/bot_commands/en.md
+++ b/assets/bot_commands/en.md
@@ -1,4 +1,4 @@
-Changeset `{ch_id}`
+Changeset [{ch_id}]({osm_link}) - "{comment}"
 
 ❗️ Importance grade: {grade}
 ⚠️ Reasons:
@@ -7,8 +7,6 @@ Changeset `{ch_id}`
 📅 Date and Time: `{date}`
 📍 Location: {location}
 🧑🏽‍💻 #User_{user_id}: [{username}]({userlink})
-
-📃 Comment: {comment}
 📃 Source: {source}
 
-📎 Related links: [OSM]({osm_link}), [OSMcha]({osmcha_link}), [OSMvis]({osmvis_link}), [Achavi]({achavi_link})
+📎 Related links: [OSMcha]({osmcha_link}), [OSMvis]({osmvis_link}), [Achavi]({achavi_link})

--- a/assets/bot_commands/fa.md
+++ b/assets/bot_commands/fa.md
@@ -1,4 +1,4 @@
-بستهٔ تغییرات `{ch_id}`
+بستهٔ تغییرات [{ch_id}]({osm_link}) - {comment}
 
 ❗️درجه اهمیت: {grade}
 ⚠️ علت(ها):
@@ -7,8 +7,6 @@
 📅 تاریخ تغییر: `{date}`
 📍مکان تغییر: {location}
 🧑🏽‍💻 #کاربر_{user_id}: [{username}]({userlink})
-
-📃 توضیحات: {comment}
 📃 منبع: {source}
 
- 📎 لینک‌های مرتبط: [OSM]({osm_link}), [OSMcha]({osmcha_link}), [OSMvis]({osmvis_link}), [Achavi]({achavi_link})
+ 📎 لینک‌های مرتبط: [OSMcha]({osmcha_link}), [OSMvis]({osmvis_link}), [Achavi]({achavi_link})


### PR DESCRIPTION
Linked the OSM changeset ID in the first line of the bot output to the OSM changeset page. This is more consistent with how they are linked in other OSM tools. Removed it from the "Related links" section. Also moved the changeset comment right behind the ID, since it's more of a "changeset title".
Finally removed the empty line above "source" for more efficient vertical space usage.

Important: I only changed the layout files, but couldn't yet test if this actually works:
[{ch_id}]({osm_link})
Would appreciate if you can try it out, Ebrahim.