### PR TITLE
Add prometheus exporter (#8)

### DIFF
--- a/conf.toml.sample
+++ b/conf.toml.sample
@@ -7,6 +7,7 @@ telegram_sus_channel = "@testosm"
 
 [app]
 fetch_intervals = 10 # in minutes
+prometheus_port = 8000
 border = "iran"
 language = "fa"
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -266,6 +266,17 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 dev = ["pre-commit", "tox"]
 
 [[package]]
+name = "prometheus-client"
+version = "0.9.0"
+description = "Python client for the Prometheus monitoring system."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+twisted = ["twisted"]
+
+[[package]]
 name = "py"
 version = "1.10.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
@@ -469,7 +480,7 @@ python-versions = "*"
 
 [metadata]
 python-versions = "^3.8"
-content-hash = "07a7a7f2aca7cab95bb21bd056fb1d362b27e273e173a5b18b4ef126a2c47d81"
+content-hash = "6a198474df203f393b5ce6d0a533149dadbb5077b308d2c78b2bdb8f1811a03a"
 
 [metadata.files]
 apscheduler = [
@@ -732,6 +743,10 @@ pillow = [
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
+]
+prometheus-client = [
+    {file = "prometheus_client-0.9.0-py2.py3-none-any.whl", hash = "sha256:b08c34c328e1bf5961f0b4352668e6c8f145b4a087e09b7296ef62cbe4693d35"},
+    {file = "prometheus_client-0.9.0.tar.gz", hash = "sha256:9da7b32f02439d8c04f7777021c304ed51d9ec180604700c1ba72a4d44dceb03"},
 ]
 py = [
     {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ apscheduler = "^3.6.3"
 numpy = "^1.19.2"
 lxml = "^4.6.2"
 toml = "^0.10.2"
+prometheus_client = "^0.9.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/src/conf.py
+++ b/src/conf.py
@@ -7,6 +7,7 @@ with open("conf.toml", "r") as f:
 country = confs["app"]["border"]
 interval = confs["app"]["fetch_intervals"]
 language = confs["app"]["language"]
+prom_port = confs["app"]["prometheus_port"]
 
 ## Pyrogram
 api_id = confs["pyrogram"]["api_id"]

--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,15 @@
 from apscheduler.schedulers.background import BackgroundScheduler
+from prometheus_client import start_http_server
 
 from src.tg_bot import app, chnl_loop
 import src.conf as conf
 
-# #TODO: Delete later
+print("Initializing prometheus endpoint")
+start_http_server(conf.prom_port)
+
 # with app:
 #     chnl_loop()
+
 
 scheduler = BackgroundScheduler()
 scheduler.add_job(chnl_loop, "interval", minutes=conf.interval)

--- a/src/prometheus.py
+++ b/src/prometheus.py
@@ -1,0 +1,15 @@
+from prometheus_client import Counter, Gauge, Summary
+
+# General
+cycle = Counter("fetch_cycles", "Total fetch cycles")
+changesets = Counter("changesets", "Total changesets")
+changeset_per_cycle = Gauge("changeset_per_cycle", "Number of changesets per cycle")
+
+# Requests
+requests = Counter("api_requests", "Total API requests", ["type"])
+req_time = Summary("api_request_seconds", "Seconds waiting for request")
+
+# Changes
+creates = Counter("change_create", "Total creation changes", ["type"])
+modifies = Counter("change_modify", "Total modification changes", ["type"])
+deletes = Counter("change_deletes", "Total deletion changes", ["type"])

--- a/src/tg_bot.py
+++ b/src/tg_bot.py
@@ -8,6 +8,7 @@ from time import sleep
 import src.analyse as ana
 import src.changeset as cha
 import src.conf as conf
+from src import prometheus as prom
 from src.chart import gen_changestat_png
 
 
@@ -28,8 +29,11 @@ api = osmapi.OsmApi()
 def chnl_loop():
     """A schedule loop which posts changesets to channels"""
 
+    prom.cycle.inc(1)
     print("Query for changesets...")
     ch_sets = cha.query_changesets(api, iran_bbox, border, conf.interval)
+    prom.changesets.inc(len(ch_sets))
+    prom.changeset_per_cycle.set(len(ch_sets))
     for ch_st in ch_sets:
         try:
             print(f"Analysing {ch_st}")


### PR DESCRIPTION
Closes #8 

Changes:
- add prometheus python client
- add exporter metrics for:
- changes, request time and count, cycles, changesets, changeset_per_cycle
- add prom port in confs (UPDATE WIKI)
- expose prometheus port